### PR TITLE
Change default id to use `-` instead of `:` so it can be selected easily

### DIFF
--- a/src/util/getInputProps.js
+++ b/src/util/getInputProps.js
@@ -19,7 +19,7 @@ export default (inputConfig, inputsState, dispatch) => (
         const hasError = typeof error !== 'undefined';
 
         return {
-            _id: [getReduxMountPoint(inputConfig), id].join(':'),
+            _id: [getReduxMountPoint(inputConfig), id].join('-'),
             value: hasError ? error : value,
             error: hasError,
 

--- a/tests/redux-inputs-spec.js
+++ b/tests/redux-inputs-spec.js
@@ -1170,7 +1170,7 @@ describe('getInputProps', () => {
     const altMountInputConfig = { _reduxMountPoint: 'alt', email: {}};
     it('returns objects with _id set', () => {
         const actual = getInputProps(basicInputConfig, basicInputState, noop);
-        expect(actual.email._id).to.equal('inputs:email');
+        expect(actual.email._id).to.equal('inputs-email');
     });
     it('handles non-errored inputs', () => {
         const actual = getInputProps(basicInputConfig, basicInputState, noop);
@@ -1199,8 +1199,8 @@ describe('getInputProps', () => {
     });
     it('handles multiple objects', () => {
         const actual = getInputProps(multiInputConfig, multiInputState, noop);
-        expect(actual.email._id).to.equal('inputs:email');
-        expect(actual.name._id).to.equal('inputs:name');
+        expect(actual.email._id).to.equal('inputs-email');
+        expect(actual.name._id).to.equal('inputs-name');
     });
     it('throws an invariant error when ids are not present in state', () => {
         const actualFn = () => getInputProps(multiInputConfig, basicInputState, noop);
@@ -1208,7 +1208,7 @@ describe('getInputProps', () => {
     });
     it('works with alternative mount points', () => {
         const actual = getInputProps(altMountInputConfig, basicInputState, noop);
-        expect(actual.email._id).to.equal('alt:email');
+        expect(actual.email._id).to.equal('alt-email');
     });
 });
 const promiseThunk = () => Promise.resolve();


### PR DESCRIPTION
This should not be an encouraged behavior, but we should make it possible for people who want to use css. 