### PR TITLE
Fixed getReduxMountPoint export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ export {
  */
 export { default as connectWithInputs } from './util/connectWithInputs';
 export { default as getInputProps } from './util/getInputProps';
-export { getInputsFromState, getReduxMountPoint } from './util/helpers';
+export { getInputsFromState } from './util/helpers';
+export { getReduxMountPoint } from './util/mountPoint';
 export { default as ReduxInputsWrapper } from './components/ReduxInputsWrapper';
 export { default as LocalInputs } from './components/LocalInputs';

--- a/tests/redux-inputs-spec.js
+++ b/tests/redux-inputs-spec.js
@@ -11,8 +11,18 @@ import getInputProps from '../src/util/getInputProps';
 import connectWithInputs from '../src/util/connectWithInputs';
 import { formSelector } from '../src/util/selectors';
 import ReduxInputsWrapper, { createOnChangeWithTransform } from '../src/components/ReduxInputsWrapper';
+import * as reduxInputsExports from '../src/index';
 
 const mockStore = configureMockStore([reduxThunk]);
+
+describe('exports', () => {
+    it('are all defined', () => {
+        Object.keys(reduxInputsExports).forEach(key => {
+            expect(key).to.not.be.undefined;
+            expect(reduxInputsExports[key], `export '${key}' is undefined`).to.not.be.undefined;
+        });
+    });
+});
 
 describe('createInputsReducer', () => {
     describe('no input config', () => {


### PR DESCRIPTION
getReduxMountPoint was exported as undefined because it is actually defined in mountPoint.js, not helpers.