### PR TITLE
Add meta field to validate actions to force async validation even when input values is unchanged

### DIFF
--- a/docs/actionCreators.md
+++ b/docs/actionCreators.md
@@ -89,6 +89,7 @@ Returns an action that when dispatched will reset the form values associated wit
 ### Note on `meta` parameter - There are some special properties available:
  - `reduxMountPoint` - automatically added to every action fired, specifying which form it is associated with 
  - `suppressChange` - adding this to the meta object for any action creator will skip any `onChange` callbacks in the inputsConfig
+ - `forceAsyncValidation` - adding this to the meta object for `validateInputs` and `updateAndValidate` will force async validation even if the value is unchanged
  - `validate` - included when running `validateInputs`
  - `initialize` - included when running `intializeInputs`, sets all changed inputs to `pristine`
  - `reset` - included when running `resetInputs`

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -213,7 +213,7 @@ export function updateAndValidate(inputConfig, update, meta = {}) {
             if (typeof validationResult === 'boolean' || typeof validationResult === 'string' || hasAsync || !validationResult) { // Or Promise
                 const change = (validationResult === true || hasAsync) ? ({ // True or hasAsync, set value
                     value: value,
-                    validating: currentlyValidating || (hasAsync && !unchanged) // Will be validating if async validator exists
+                    validating: currentlyValidating || (hasAsync && !unchanged) || (hasAsync && meta.forceAsyncValidation) // Will be validating if async validator exists
                 }) : ({ // False returned, input invalid
                     value: prev,
                     error: typeof value === 'undefined' ? '' : value,

--- a/tests/redux-inputs-spec.js
+++ b/tests/redux-inputs-spec.js
@@ -538,6 +538,34 @@ describe('updateAndValidate thunk', () => {
             }
         }));
     });
+    it('correctly fires async validation when input is unchanged if forceAsyncValidation meta is present', () => {
+        const expectedActions = [{
+            error: false,
+            meta: { reduxMountPoint: 'inputs', forceAsyncValidation: true },
+            payload: { email: { validating: true, value: 'test@test.com' }},
+            type: 'RI_SET_INPUT'
+        }, {
+            error: false,
+            meta: { reduxMountPoint: 'inputs', forceAsyncValidation: true },
+            payload: { email: { value: 'test@test.com' }},
+            type: 'RI_SET_INPUT'
+        }];
+        const store = mockStore({ inputs: { email: { value: 'test@test.com' } } });
+        const thunk = updateAndValidate({
+            email: {
+                validator: () => Promise.resolve()
+            }
+        }, {
+            email: 'test@test.com'
+        },
+        {
+            forceAsyncValidation: true
+        });
+
+        return store.dispatch(thunk).then(() => {
+            expect(store.getActions()).to.deep.equal(expectedActions);
+        });
+    });
     it('correctly dispatches async validation VALID changes', () => {
         const expectedActions = [{
             error: false,


### PR DESCRIPTION
If multiple input fields are related in their values, then you may have a situation where updating one of the fields should force the other field to be validated. Prior to this change, if the field being re-validated has an async validator, the async validator's promise response will not be caught.

This adds a meta field to force the async validation to occur.